### PR TITLE
add workflow to check we're current with Charmcraft

### DIFF
--- a/.github/workflows/current.yaml
+++ b/.github/workflows/current.yaml
@@ -1,7 +1,6 @@
 name: Current with Charmcraft
 
 on:
-  pull_request:
   push:
     branches:
       - main


### PR DESCRIPTION
I'm adding a workflow to check that this repo's main branch is current with the profiles in Charmcraft's main branch. My idea is that the workflow should run on a regular (weekly?) basis. If there's a difference between Charmcraft and this repo, the workflow should open a PR to update the charms. I'll implement that later.