### PR TITLE
ci: add zizmor workflow

### DIFF
--- a/.github/workflows/charm-checks.yaml
+++ b/.github/workflows/charm-checks.yaml
@@ -8,11 +8,15 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   charm-checks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
       - name: Install tox and tox-uv

--- a/.github/workflows/code-checks.yaml
+++ b/.github/workflows/code-checks.yaml
@@ -8,11 +8,15 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   code-checks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
       - name: Lint

--- a/.github/workflows/current.yaml
+++ b/.github/workflows/current.yaml
@@ -15,6 +15,8 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   current:
     runs-on: ubuntu-latest
@@ -23,11 +25,13 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: initial-charms
+          persist-credentials: false
       - name: Checkout Charmcraft
         uses: actions/checkout@v6
         with:
           repository: canonical/charmcraft
           path: charmcraft
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
       - name: Set up Charmcraft

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -13,6 +13,8 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   integration-kubernetes-extra:
     runs-on: ubuntu-latest
@@ -21,6 +23,8 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
       - name: Install tox and tox-uv
@@ -54,6 +58,8 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
       - name: Install tox and tox-uv

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,34 @@
+name: Workflow static checks
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
+
+      - name: Run zizmor
+        run: uvx zizmor --format=sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif
+          category: zizmor

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,7 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "actions/*": ref-pin
+        "github/*": ref-pin
+        "pypa/*": ref-pin


### PR DESCRIPTION
manThis PR adds a workflow that runs Zizmor to do static analysis of all of the GitHub action workflows.

The same pinning configuration is used as in canonical/operator (meaning the same acceptance of risk).

A couple of minor adjustments are also done to the workflows in order to have Zizmor pass without issues, namely setting `persist-credentials: false` for checkouts and setting empty permissions at the start of each workflow.