### PR TITLE
ci: configure dependabot separately for each charm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,33 @@ updates:
     cooldown:
       default-days: 7
   - package-ecosystem: "uv"
-    directory: "/"
+    directory: "/kubernetes"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "uv"
+    directory: "/kubernetes-extra"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+    cooldown:
+      default-days: 7
+    ignore:
+      - dependency-name: "ops"
+      - dependency-name: "ruff"
+      - dependency-name: "codespell"
+      - dependency-name: "pyright"
+      - dependency-name: "coverage"
+      - dependency-name: "pytest"
+      - dependency-name: "pytest-jubilant"
+      - dependency-name: "jubilant"
+      - dependency-name: "PyYAML"
+  - package-ecosystem: "uv"
+    directory: "/machine"
     schedule:
       interval: "monthly"
     labels:


### PR DESCRIPTION
Dependabot seems to stop when it finds one set of deps to update. This PR splits our dependabot config into separate rules for each charm: `kubernetes`, `kubernetes-extra`, and `machine`. For `kubernetes-extra`, I'm ignoring the deps from `kubernetes` (as in https://github.com/canonical/operator/pull/2426).

I wondered whether we should use `open-pull-requests-limit` to prevent PRs from being opened for `kubernetes` and `machine` (as the changes actually need making in Charmcraft), but that would probably be overcomplicating things.

---

This repo has another Python project - in the `.implement` directory. I'm ignoring that in the dependabot config because I have separate work ongoing that refactors the tools. We can update the dependabot config again when that work is done.