### PR TITLE
ci: improve approach to non-draft PRs

### DIFF
--- a/.github/workflows/current.yaml
+++ b/.github/workflows/current.yaml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: "50 22 * * 0"
   pull_request:
-    paths:
-      - kubernetes/**
-      - machine/**
     types:
       - ready_for_review
   push:

--- a/.github/workflows/current.yaml
+++ b/.github/workflows/current.yaml
@@ -5,7 +5,10 @@ on:
     - cron: "50 22 * * 0"
   pull_request:
     types:
-      - ready_for_review
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review  # Triggers on the transition. GitHub doesn't do this by default.
   push:
     branches:
       - main
@@ -16,6 +19,9 @@ permissions: {}
 
 jobs:
   current:
+    # We typically leave a PR in draft status until the corresponding Charmcraft PR has merged.
+    # So we only want to check against Charmcraft on non-draft PRs.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repo

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -5,8 +5,6 @@ on:
     paths:
       - kubernetes-extra/**
       - machine/**
-    types:
-      - ready_for_review
   push:
     branches:
       - main


### PR DESCRIPTION
I previously restricted integration tests and the Charmcraft consistency check to PRs with `ready_for_review` type. This turned out to be annoying:

- It's useful to see the result of integration tests before a PR is finished, especially if the PR is waiting for a corresponding Charmcraft PR to merge (which we'll typically indicate by keeping the PR in draft status).

- As I now understand, `ready_for_review` only triggers on the transition out of draft. So if a PR is updated after review, the integration tests and consistency check won't run again.

So I'm changing the approach:

- Integration tests will run on any PR, provided the stored charms have changed. There are only two charms to test, and those charms are as small as they're ever going to get. This is hardly an infrastructure burden.

- The consistency check will run whenever a PR is created/updated, provided the PR is non-draft. The check will also run on the transition out of draft (as currently).

I'm also fixing a bug (arguably) in the consistency check workflow. Currently, the workflow requires the stored charms to have changed in a PR. But the PR could be changing our charm generation logic, in which case we should also run the workflow. So I'm removing the requirement.