### PR TITLE
add juju_setup markers, fix double resolve()

### DIFF
--- a/.implement/kubernetes-extra.py
+++ b/.implement/kubernetes-extra.py
@@ -44,7 +44,6 @@ def main():
 
     # Enable the integration test that checks the workload version.
     r = rewriter.Rewriter('tests/integration/test_charm.py')
-    r.fwd('import pytest', remove_line=True)
     r.fwd(
         prefix='@pytest.mark.skip',
         change='# @pytest.mark.skip',

--- a/kubernetes-extra/tests/integration/test_charm.py
+++ b/kubernetes-extra/tests/integration/test_charm.py
@@ -8,6 +8,7 @@ import logging
 import pathlib
 
 import jubilant
+import pytest
 import yaml
 
 logger = logging.getLogger(__name__)
@@ -15,12 +16,13 @@ logger = logging.getLogger(__name__)
 METADATA = yaml.safe_load(pathlib.Path("charmcraft.yaml").read_text())
 
 
+@pytest.mark.juju_setup  # See https://github.com/canonical/pytest-jubilant/#juju_setup
 def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     """Deploy the charm under test."""
     resources = {
         "some-container-image": METADATA["resources"]["some-container-image"]["upstream-source"]
     }
-    juju.deploy(charm.resolve(), app="my-application", resources=resources)
+    juju.deploy(charm, app="my-application", resources=resources)
     juju.wait(jubilant.all_active)
 
 

--- a/kubernetes/tests/integration/test_charm.py
+++ b/kubernetes/tests/integration/test_charm.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 METADATA = yaml.safe_load(pathlib.Path("charmcraft.yaml").read_text())
 
 
+@pytest.mark.juju_setup  # See https://github.com/canonical/pytest-jubilant/#juju_setup
 def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     """Deploy the charm under test."""
     resources = {

--- a/kubernetes/tests/integration/test_charm.py
+++ b/kubernetes/tests/integration/test_charm.py
@@ -22,7 +22,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     resources = {
         "some-container-image": METADATA["resources"]["some-container-image"]["upstream-source"]
     }
-    juju.deploy(charm.resolve(), app="my-application", resources=resources)
+    juju.deploy(charm, app="my-application", resources=resources)
     juju.wait(jubilant.all_active)
 
 

--- a/machine/tests/integration/test_charm.py
+++ b/machine/tests/integration/test_charm.py
@@ -13,6 +13,7 @@ import pytest
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.juju_setup  # See https://github.com/canonical/pytest-jubilant/#juju_setup
 def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     """Deploy the charm under test."""
     juju.deploy(charm.resolve(), app="my-application")

--- a/machine/tests/integration/test_charm.py
+++ b/machine/tests/integration/test_charm.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.juju_setup  # See https://github.com/canonical/pytest-jubilant/#juju_setup
 def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     """Deploy the charm under test."""
-    juju.deploy(charm.resolve(), app="my-application")
+    juju.deploy(charm, app="my-application")
     juju.wait(jubilant.all_active)
 
 


### PR DESCRIPTION
I'm making two improvements to the integration tests of the `kubernetes` and `machine` profiles:

- Mark the `test_deploy` function as a setup function
- Don't `resolve()` the charm to deploy - the `charm` fixture defined in `conftest.py` already returns a resolved path

I had to also adjust the implementation script for the `kubernetes-extra` charm: we need to keep pytest around for the setup marker.