### PR TITLE
docs: prepare for archiving

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This repository is no longer used. For guidance about updating Charmcraft profiles, see [HACKING.md in the Ops repository](https://github.com/canonical/operator/blob/main/HACKING.md#updating-the-charmcraft-profiles).
+
 This repo contains tools for maintaining the `kubernetes` and `machine` profiles of [Charmcraft](https://github.com/canonical/charmcraft). The tools are primarily intended to be used by the Charm Tech team at Canonical.
 
 In the Charmcraft source, profiles are stored as .j2 template files. For example, [charm.py.j2](https://github.com/canonical/charmcraft/blob/main/charmcraft/templates/init-kubernetes/src/charm.py.j2). This enables `charmcraft init` to fill in the charm name and other details, but testing the profiles can be awkward.


### PR DESCRIPTION
We decided to archive this repo because we plan to stop shipping `uv.lock` with the Charmcraft profiles - which will make them simpler to maintain. This PR adds a note to the README.

[Preview](https://github.com/dwilding/charmcraft-profile-tools/blob/archive/README.md)